### PR TITLE
Fix : Updated API routes

### DIFF
--- a/utils/CaraousalInfo.js
+++ b/utils/CaraousalInfo.js
@@ -51,7 +51,7 @@ const CaraousalInfo = ({ allData, index, endpoint }) => {
   const endpointData = getDataByEndpoint(endpoint);
 
   const handleVisitSubmit = () => {
-    (endpoint === "players" || endpoint === "players-versus") ? (router.push(`/playerData/${tag}`)) : (router.push(`/clanData/${tag}`))
+    (endpoint === "players" || endpoint === "players-builder-base") ? (router.push(`/playerData/${tag}`)) : (router.push(`/clanData/${tag}`))
 
   }
   return (


### PR DESCRIPTION
API routes for rankings are updated in official Clash of clans API docs , 

- "player-versus" -> "player-builder-base"
- "clan-versus" -> "clan-builder-base"